### PR TITLE
[DO NOT SUBMIT] Verify struct output perf. improvement

### DIFF
--- a/benchmarks/benchmark_serving_structured_output.py
+++ b/benchmarks/benchmark_serving_structured_output.py
@@ -162,20 +162,13 @@ def sample_requests(tokenizer: PreTrainedTokenizerBase,
 
     elif args.dataset == "grammar":
         schema = """
-        root ::= select_statement
-
-        select_statement ::= "SELECT " column " from " table " where " condition
-
-        column ::= "col_1 " | "col_2 "
-
-        table ::= "table_1 " | "table_2 "
-
-        condition ::= column "= " number
-
-        number ::= "1 " | "2 "
+        root        ::= en-char+ ([ \\t\\n] en-char+)*
+        en-char     ::= letter | digit | punctuation
+        letter      ::= [a-zA-Z]
+        digit       ::= [0-9]
+        punctuation ::= [!"#$%&'()*+,-./:;<=>?@[\\\\\\]^_`{|}~]
         """
-        prompt = "Generate an SQL query to show the 'username' \
-            and 'email' from the 'users' table."
+        prompt = "tell a story about Spring ,at least 1024 words"
 
         input_len = len(tokenizer(prompt).input_ids)
         print(f"Input length of the prompt: {input_len} tokens")


### PR DESCRIPTION
On top of https://github.com/vllm-project/vllm/pull/17440

Applying grammar/prompt mentioned in https://github.com/vllm-project/vllm/pull/14962 to verify metrics.

The PR is meant to show the diff, not for real pull.

Usage

```
VLLM_USE_V1=0 python /home/ray/default/vllm/benchmarks/benchmark_offline_structured_output.py \
  --model=Qwen/Qwen2.5-3B-Instruct \
  --dataset=grammar \
  --num-prompt=100 \
  --async-mode \
  --structured-output-backend xgrammar \
  --output-len=2048
```